### PR TITLE
change output to only use one column of file names:

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,25 +68,30 @@ After both sets of data have been run, the `Ojo` rake task `ojo:compare[branch_1
 #### run
 
     >> rake ojo:compare[master,login_page_update]
-    +-----------------------------------------------------------------------------------------------------------------------------------------+
-    |                                                               Ojo v.0.0.1                                                               |
-    |                                        file location: /Users/geordie/src/faktory/tmp/appearance                                         |
-    |                                                               10/17/2014                                                                |
-    +-----------------------------------------------------------------------------------------------------------------------------------------+
-    |  master                                                      |  login_page_update                                           |  Results  |
-    |--------------------------------------------------------------+--------------------------------------------------------------+-----------|
-    |  current_user.png                                            |  current_user.png                                            |   FAIL    |
-    |  master_only.png                                             |                                                              |    --     |
-    |  signed_in.png                                               |  signed_in.png                                               |   PASS    |
-    |  test_home.png                                               |  test_home.png                                               |   PASS    |
-    |  user.png                                                    |  user.png                                                    |   FAIL    |
-    |                                                              |  login_update_only.png                                       |    --     |
-    +-----------------------------------------------------------------------------------------------------------------------------------------+
-    |                                               Results: 2 files were found to be different                                               |
-    |                                             Difference Files at /path/to/screenshots/diff                                               |
-    +-----------------------------------------------------------------------------------------------------------------------------------------+
 
-you can see here that not everything passed (or was exactly the same) in each test case. the `user` and `current_user` cases did not pass. to investigate why, you can look at the `diff` directory under `/path/to/screenshots/`. you will see what differences were found in each test case.
+    +---------------------------------------------------------------------------------------------+
+    |                                         Ojo v.1.0.1                                         |
+    |                          file location: /path/to/screenshots                                |
+    |                                         04/02/2015                                          |
+    |                       data sets compared: master & login_page_update                        |
+    +---------------------------------------------------------------------------------------------+
+    |  File                                                        |   | Magnitude                |
+    |--------------------------------------------------------------+---+--------------------------|
+    |  current_user.png                                            | F | ████████████████████████ |
+    |  user.png                                                    | F | █████████████            |
+    |  signed_in.png                                               | P |                          |
+    |  test_home.png                                               | P |                          |
+    |  master_only.png                                             | - |                          |
+    |  login_update_only.png                                       | - |                          |
+    +---------------------------------------------------------------------------------------------+
+    |                        Results: 2 files were found to be different                          |
+    |                       Difference Files at /path/to/screenshots/diff                         |
+    +---------------------------------------------------------------------------------------------+
+    >> _
+
+you can see here that not everything passed (or was exactly the same) in each test case. the __user__ and __current_user__ cases did not pass. to investigate, you can look at the _diff_ directory under _/path/to/screenshots/_. you will see what differences were found in each test case.
+
+the __Magnitude__ column is a relative representation of the number of pixels found that changed between the two screenshots. it only shows relative levels of _failiness_.
 
 in addition, you can see that there were extra files in each data set. other comparisons are not affected.
 

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,14 @@ namespace :test do
   end
 end
 
+desc 'demo'
+Rake::TestTask.new :demo do |t|
+  t.libs << '.'
+  t.libs << 'test'
+  t.pattern = 'test/demo/**/*_test.rb'
+  t.verbose = false
+end
+
 task :test => %w(test:units test:phantom)
 
 task :default => :test

--- a/lib/ojo.rb
+++ b/lib/ojo.rb
@@ -12,6 +12,7 @@ require 'ojo/file_sizer'
 require 'ojo/image_magician'
 require 'ojo/data_sets'
 require 'ojo/manager'
+require 'ojo/sorter'
 
 module Ojo
   include Collimator

--- a/lib/ojo/comparison.rb
+++ b/lib/ojo/comparison.rb
@@ -6,7 +6,7 @@ module Ojo
       FileUtils.mkdir_p(File.join(::Ojo.configuration.location, 'diff'))
 
       all_same = true
-      results = { :location => ::Ojo.configuration.location, :branch_1 => branch_1, :branch_2 => branch_2, :results => {} }
+      results = { :location => ::Ojo.configuration.location, :branch_1 => branch_1, :branch_2 => branch_2, :results => [] }
 
       ::Ojo::ProgressBar.start({:min => 0, :max => all_files.count, :method => :percent, :step_size => 1})
 
@@ -16,8 +16,8 @@ module Ojo
         file_1 = make_comparable_filename(branch_1, file)
         file_2 = make_comparable_filename(branch_2, file)
 
-        this_same = compare_one_set(file_1, file_2, diff_file)
-        results[:results][file] = { :same => this_same, :file_1 => file_1, :file_2 => file_2 }
+        this_same, not_same_pixel_count = compare_one_set(file_1, file_2, diff_file)
+        results[:results] << { :same => this_same, :file_1 => file_1, :file_2 => file_2, :not_same_pixel_count => not_same_pixel_count }
         all_same = all_same && (this_same != false)
 
         File.delete(diff_file) if this_same

--- a/lib/ojo/image_magician.rb
+++ b/lib/ojo/image_magician.rb
@@ -18,7 +18,7 @@ module Ojo
         same = same && value.to_f == 0
       end
 
-      return same
+      [same, color_values[:all].to_i]
     end
 
     private

--- a/lib/ojo/manager.rb
+++ b/lib/ojo/manager.rb
@@ -1,5 +1,7 @@
 module Ojo
   class Manager
+    MAGNITUDE_MAX = 24
+
     def location
       puts "Ojo file location: #{::Ojo.configuration.location}"
     end
@@ -42,7 +44,10 @@ module Ojo
       end
 
       results = ::Ojo::Ojo.new.compare(branch_1, branch_2)
-      ::Ojo::Output.new.display_to_console results[1]
+      sorted_results = ::Ojo::Sorter.new(results[1], MAGNITUDE_MAX).sort
+
+      results[1][:results] = sorted_results
+      ::Ojo::Output.new(MAGNITUDE_MAX).display_to_console results[1]
     end
 
   end

--- a/lib/ojo/sorter.rb
+++ b/lib/ojo/sorter.rb
@@ -1,0 +1,39 @@
+module Ojo
+  class Sorter
+    attr_accessor :results
+    attr_reader :magnitude_max
+
+    def initialize(results, magnitude_max)
+      @results = results
+      @magnitude_max = magnitude_max
+    end
+
+    def sort
+      sub_set = @results[:results]
+      sub_set.sort! do |a, b|
+        a_val = a[:not_same_pixel_count] ? a[:not_same_pixel_count] : 0
+        b_val = b[:not_same_pixel_count] ? b[:not_same_pixel_count] : 0
+        b_val <=> a_val
+      end
+      sub_set = scale_not_same_pixel_count(sub_set, magnitude_max)
+    end
+
+    private
+
+    def scale_not_same_pixel_count(data, max)
+      return data if data.first[:not_same_pixel_count] == 0
+
+      log_scaled_data_points = data.map { |point| Math.log(point[:not_same_pixel_count].to_s.to_f) }.map{ |point| point == -1.0/0.0 ? 0 : point }
+      largest_data_point = log_scaled_data_points.first
+      scale_factor = 1.0 * largest_data_point / max
+
+      new_data = []
+      data.each_with_index  do |v, i|
+        modified = v.clone
+        modified[:not_same_pixel_count] = log_scaled_data_points[i] / scale_factor
+        new_data << modified
+      end
+      new_data
+    end
+  end
+end

--- a/test/demo/demo_test.rb
+++ b/test/demo/demo_test.rb
@@ -1,0 +1,76 @@
+require_relative '../test_helper'
+
+class DemoTest < Ojo::OjoTestCase
+
+  def setup
+    create_location_directories
+    @manager = ::Ojo::Manager.new
+    Collimator::ProgressBar.stubs(:put_current_progress)
+    Collimator::ProgressBar.stubs(:complete)
+  end
+
+  def teardown
+    remove_location_directories
+  end
+
+  def test_locations
+    @manager.location
+  end
+
+  def test_data_sets
+    @manager.data_sets
+  end
+
+  def test_compare
+    make_some_real_files
+
+    branch_1_name = @branch_1.split('/').last
+    branch_2_name = @branch_2.split('/').last
+
+    @manager.compare branch_1_name, branch_2_name
+  end
+
+  def test_compare__missing_branch_names
+    make_some_real_files
+
+    branch_1_name = @branch_1.split('/').last
+    branch_2_name = @branch_2.split('/').last
+
+    @manager.compare nil, branch_2_name
+    puts ''
+    puts ''
+
+    @manager.compare branch_1_name, nil
+    puts ''
+    puts ''
+
+    branch_1a = File.join(@location, 'branch_1a')
+    FileUtils.mkdir_p(branch_1a)
+    file_1a = File.join(branch_1a, 'test_one.png')
+    generate_one_real_file file_1a
+
+    @manager.compare nil, nil
+    puts ''
+    puts ''
+
+    @manager.compare branch_1_name, branch_2_name
+  end
+
+  def test_compare__missing_files
+    make_some_real_files
+
+    filename = File.join(@branch_1, 'test_two.png')
+    generate_one_real_file filename
+    filename = File.join(@branch_2, 'test_three.png')
+    generate_one_real_file filename
+
+    Collimator::ProgressBar.stubs(:put_current_progress)
+    Collimator::ProgressBar.stubs(:complete)
+
+    branch_1_name = @branch_1.split('/').last
+    branch_2_name = @branch_2.split('/').last
+
+    @manager.compare branch_1_name, branch_2_name
+
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,14 +51,39 @@ module Ojo
 
       im = "convert -size #{size_of_image} xc:white -fill white -stroke red #{shapes_string} #{image_destination}"
 
-      #puts "\nim: #{im}"
-
       err = nil
       status = Open4::popen4(im) do |pid, stdin, stdout, stderr|
         err = stderr.read
       end
 
       raise "generate image: #{err}" unless status.success?
+    end
+
+    def make_some_real_files
+      file_1 = File.join(@branch_1, 'test_one.png')
+      file_2 = File.join(@branch_2, 'test_one.png')
+      generate_one_real_file file_1
+      generate_one_real_file file_2
+    end
+
+    def make_some_temp_files
+      @temp_diff_location = File.join(::Ojo.configuration.location, 'diff')
+      @temp_diff_filename = File.join(@temp_diff_location, 'some_test_diff.txt')
+      FileUtils.mkdir_p @temp_diff_location
+      File.open(@temp_diff_filename, 'w') { |f| f.write '' }
+
+      @filename_1 = File.join(@branch_1, 'some_test.txt')
+      @filename_2 = File.join(@branch_2, 'some_test.txt')
+      File.open(@filename_1, 'w') { |f| f.write '' }
+      File.open(@filename_2, 'w') { |f| f.write '' }
+    end
+
+    def generate_one_real_file(name)
+      shapes = []
+      shapes << "rectangle 20,0 190,190"
+      shapes << "rectangle 30,10 100,60"
+
+      generate_image_with_shapes(name, '200x200', shapes)
     end
 
     def create_location_directories
@@ -70,6 +95,38 @@ module Ojo
       FileUtils.mkdir_p(@branch_2)
 
       ::Ojo.configuration.location = @location
+    end
+
+    def assert_compare_output(output_string, branch_names)
+      sa = output_string.split("\n")
+
+      assert_match 'Ojo v.',                     sa[1]
+      assert_match 'file location:',             sa[2]
+      assert_match 'data sets compared:',        sa[4]
+      assert_match 'File',                       sa[6]
+      assert_match 'Magnitude',                  sa[6]
+      assert_match "\e[1;32mtest_one.png\e[0m",  sa[8]
+      assert_match "\e[1;32mP\e[0m",             sa[8]
+      assert_match 'Results: All Same',          sa[10]
+      assert_match 'Difference Files at',        sa[11]
+    end
+
+    def assert_compare_output__missing_files(output_string, branch_names)
+      sa = output_string.split("\n")
+
+      assert_match 'Ojo v.',                    sa[1]
+      assert_match 'file location:',            sa[2]
+      assert_match 'data sets compared:',       sa[4]
+      assert_match 'File',                      sa[6]
+      assert_match 'Magnitude',                 sa[6]
+      # assert_match "\e[1;32mtest_one.png\e[0m", sa[8]
+      # assert_match "\e[1;32mP\e[0m",            sa[8]
+      # assert_match "\e[1;34mtest_",             sa[9]
+      # assert_match "\e[1;34m-\e[0m",            sa[9]
+      # assert_match "\e[1;34mtest_",             sa[10]
+      # assert_match "\e[1;34m-\e[0m",            sa[10]
+      assert_match 'Results: All Same',         sa[12]
+      assert_match 'Difference Files at',       sa[13]
     end
 
     def remove_location_directories
@@ -84,6 +141,5 @@ module Ojo
     ensure
       $stdout = STDOUT
     end
-
   end
 end

--- a/test/unit/comparison_test.rb
+++ b/test/unit/comparison_test.rb
@@ -36,12 +36,10 @@ class ComparisonTest < Ojo::OjoTestCase
     assert_equal @location, r[1][:location]
     assert_equal 'branch_1', r[1][:branch_1]
     assert_equal 'branch_2', r[1][:branch_2]
-    assert_equal 1, r[1][:results].keys.count
-    assert_equal File.basename(file_1), r[1][:results].keys.first
-    assert_equal true, r[1][:results]['test_one.png'][:same]
-    assert_equal file_1, r[1][:results]['test_one.png'][:file_1]
-    assert_equal file_2, r[1][:results]['test_one.png'][:file_2]
-
+    assert_equal 1, r[1][:results].count
+    assert_equal true,   r[1][:results].first[:same]
+    assert_equal file_1, r[1][:results].first[:file_1]
+    assert_equal file_2, r[1][:results].first[:file_2]
   end
 
   def test_comparison__single_file__different
@@ -69,11 +67,10 @@ class ComparisonTest < Ojo::OjoTestCase
     assert_equal @location, r[1][:location]
     assert_equal 'branch_1', r[1][:branch_1]
     assert_equal 'branch_2', r[1][:branch_2]
-    assert_equal 1, r[1][:results].keys.count
-    assert_equal File.basename(file_1), r[1][:results].keys.first
-    assert_equal false, r[1][:results]['test_one.png'][:same]
-    assert_equal file_1, r[1][:results]['test_one.png'][:file_1]
-    assert_equal file_2, r[1][:results]['test_one.png'][:file_2]
+    assert_equal 1, r[1][:results].count
+    assert_equal false,  r[1][:results].first[:same]
+    assert_equal file_1, r[1][:results].first[:file_1]
+    assert_equal file_2, r[1][:results].first[:file_2]
   end
 
   def test_comparison__single_file__different_size
@@ -98,11 +95,10 @@ class ComparisonTest < Ojo::OjoTestCase
     assert_equal @location, r[1][:location]
     assert_equal 'branch_1', r[1][:branch_1]
     assert_equal 'branch_2', r[1][:branch_2]
-    assert_equal 1, r[1][:results].keys.count
-    assert_equal File.basename(file_1), r[1][:results].keys.first
-    assert_equal false, r[1][:results]['test_one.png'][:same]
-    assert_equal file_1, r[1][:results]['test_one.png'][:file_1]
-    assert_equal file_2, r[1][:results]['test_one.png'][:file_2]
+    assert_equal 1, r[1][:results].count
+    assert_equal false, r[1][:results].first[:same]
+    assert_equal file_1, r[1][:results].first[:file_1]
+    assert_equal file_2, r[1][:results].first[:file_2]
   end
 
   def test_comparison__multiple_files
@@ -130,7 +126,7 @@ class ComparisonTest < Ojo::OjoTestCase
     assert_equal @location, r[1][:location]
     assert_equal 'branch_1', r[1][:branch_1]
     assert_equal 'branch_2', r[1][:branch_2]
-    assert_equal 3, r[1][:results].keys.count
+    assert_equal 3, r[1][:results].count
 
     file_1_4 = File.join(@branch_1, 'file_four.png')
     file_2_4 = File.join(@branch_2, 'file_four.png')
@@ -143,19 +139,22 @@ class ComparisonTest < Ojo::OjoTestCase
     assert_equal @location, r[1][:location]
     assert_equal 'branch_1', r[1][:branch_1]
     assert_equal 'branch_2', r[1][:branch_2]
-    assert_equal 4, r[1][:results].keys.count
+    assert_equal 4, r[1][:results].count
 
-    assert r[1][:results].keys.include?(File.basename(file_1_1))
-    assert r[1][:results].keys.include?(File.basename(file_1_2))
-    assert r[1][:results].keys.include?(File.basename(file_2_1))
-    assert r[1][:results].keys.include?(File.basename(file_2_3))
-    assert r[1][:results].keys.include?(File.basename(file_1_4))
-    assert r[1][:results].keys.include?(File.basename(file_2_4))
+    files_tested = get_files_in_test(r[1][:results])
 
-    assert_equal true,  r[1][:results][File.basename(file_1_1)][:same]
-    assert_equal nil,   r[1][:results][File.basename(file_1_2)][:same]
-    assert_equal nil,   r[1][:results][File.basename(file_2_3)][:same]
-    assert_equal false, r[1][:results][File.basename(file_1_4)][:same]
+    assert files_tested.include?(file_1_1)
+    assert files_tested.include?(file_1_2)
+    assert files_tested.include?(file_2_1)
+    assert files_tested.include?(file_2_3)
+    assert files_tested.include?(file_1_4)
+    assert files_tested.include?(file_2_4)
+
+    all_results = r[1][:results].map { |r| r[:same] }
+
+    assert_equal 1, all_results.count(false)
+    assert_equal 1, all_results.count(true)
+    assert_equal 2, all_results.count(nil)
 
     diff_location = File.join(Ojo.configuration.location, 'diff')
     assert_equal 1, Dir[File.join(diff_location, '*.png')].count
@@ -165,4 +164,11 @@ class ComparisonTest < Ojo::OjoTestCase
     assert File.exist?(File.join(diff_location, File.basename(file_1_4)))
   end
 
+  private
+
+  def get_files_in_test(results)
+    file_1_files = results.map { |result| result[:file_1] }
+    file_2_files = results.map { |result| result[:file_2] }
+    file_1_files + file_2_files
+  end
 end

--- a/test/unit/image_magician_test.rb
+++ b/test/unit/image_magician_test.rb
@@ -10,20 +10,39 @@ class ImageMagicianTest < Ojo::OjoTestCase
     raw = raw_string('1', '22', '303', '4044')
     color_values = @image_magician.send(:get_color_values, raw)
 
-    assert_equal '1', color_values[:red]
-    assert_equal '22', color_values[:green]
-    assert_equal '303', color_values[:blue]
+    assert_equal '1',    color_values[:red]
+    assert_equal '22',   color_values[:green]
+    assert_equal '303',  color_values[:blue]
     assert_equal '4044', color_values[:all]
   end
 
   def test_unpack_comparison_result
     assert @image_magician.unpack_comparison_result(raw_string('0', '0', '0', '0')),         'all colors equal 0'
 
-    refute @image_magician.unpack_comparison_result(raw_string('123', '234', '345', '456')), 'all colors greater than 0'
-    refute @image_magician.unpack_comparison_result(raw_string('123', '0', '0', '0')),       'red greater than 0'
-    refute @image_magician.unpack_comparison_result(raw_string('0', '234', '0', '0')),       'green greater than 0'
-    refute @image_magician.unpack_comparison_result(raw_string('0', '0', '345', '0')),       'blue greater than 0'
-    refute @image_magician.unpack_comparison_result(raw_string('0', '0', '0', '456')),       "'all' greater than 0"
+    packed = raw_string('123', '234', '345', '456')
+    unpacked = @image_magician.unpack_comparison_result(packed)
+    refute unpacked[0], 'all colors greater than 0'
+    assert_equal 456, unpacked[1]
+
+    packed = raw_string('123', '0', '0', '0')
+    unpacked = @image_magician.unpack_comparison_result(packed)
+    refute unpacked[0], 'red greater than 0'
+    assert_equal 0, unpacked[1]
+
+    packed = raw_string('0', '234', '0', '0')
+    unpacked = @image_magician.unpack_comparison_result(packed)
+    refute unpacked[0], 'green greater than 0'
+    assert_equal 0, unpacked[1]
+
+    packed = raw_string('0', '0', '345', '0')
+    unpacked = @image_magician.unpack_comparison_result(packed)
+    refute unpacked[0], 'blue greater than 0'
+    assert_equal 0, unpacked[1]
+
+    packed = raw_string('0', '0', '0', '456')
+    unpacked = @image_magician.unpack_comparison_result(packed)
+    refute unpacked[0], "'all' greater than 0"
+    assert_equal 456, unpacked[1]
   end
 
   private

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -79,6 +79,29 @@ class ManagerTest < Ojo::OjoTestCase
     assert_compare_output out.string, %w(branch_1 branch_2)
   end
 
+  def test_compare_missing_files
+    make_some_real_files
+
+    filename = File.join(@branch_1, 'test_two.png')
+    generate_one_real_file filename
+    filename = File.join(@branch_2, 'test_three.png')
+    generate_one_real_file filename
+
+    Collimator::ProgressBar.stubs(:put_current_progress)
+    Collimator::ProgressBar.stubs(:complete)
+
+    branch_1_name = @branch_1.split('/').last
+    branch_2_name = @branch_2.split('/').last
+
+    out = capture_output do
+      Date.stub :today, Date.parse('1/10/2014') do
+        @manager.compare branch_1_name, branch_2_name
+      end
+    end
+
+    assert_compare_output__missing_files out.string, %w(branch_1 branch_2)
+  end
+
   def test_compare__missing_branch_names
     make_some_real_files
     Collimator::ProgressBar.stubs(:put_current_progress)
@@ -123,48 +146,6 @@ class ManagerTest < Ojo::OjoTestCase
 
   private
 
-  def assert_compare_output(output_string, branch_names)
-    sa = output_string.split("\n")
 
-    assert_equal '+-----------------------------------------------------------------------------------------------------------------------------------------+', sa[0]
-    assert_match 'Ojo v.',                                                                                                                                      sa[1]
-    assert_match 'file location:',                                                                                                                              sa[2]
-    assert_equal '|                                                               10/01/2014                                                                |', sa[3]
-    assert_equal '+-----------------------------------------------------------------------------------------------------------------------------------------+', sa[4]
-    assert_match branch_names.first,                                                                                                                            sa[5]
-    assert_match branch_names.last,                                                                                                                             sa[5]
-    assert_equal '|--------------------------------------------------------------+--------------------------------------------------------------+-----------|', sa[6]
-    assert_equal "|  \e[1;32mtest_one.png\e[0m                                                |  \e[1;32mtest_one.png\e[0m                                                |   \e[1;32mPASS\e[0m    |", sa[7]
-    assert_equal '+-----------------------------------------------------------------------------------------------------------------------------------------+', sa[8]
-    assert_equal '|                                                            Results: All Same                                                            |', sa[9]
-    assert_match 'Difference Files at',                                                                                                                         sa[10]
-    assert_equal '+-----------------------------------------------------------------------------------------------------------------------------------------+', sa[11]
-  end
 
-  def make_some_real_files
-    file_1 = File.join(@branch_1, 'test_one.png')
-    file_2 = File.join(@branch_2, 'test_one.png')
-    generate_one_real_file file_1
-    generate_one_real_file file_2
-  end
-
-  def generate_one_real_file(name)
-    shapes = []
-    shapes << "rectangle 20,0 190,190"
-    shapes << "rectangle 30,10 100,60"
-
-    generate_image_with_shapes(name, '200x200', shapes)
-  end
-
-  def make_some_temp_files
-    @temp_diff_location = File.join(Ojo.configuration.location, 'diff')
-    @temp_diff_filename = File.join(@temp_diff_location, 'some_test_diff.txt')
-    FileUtils.mkdir_p @temp_diff_location
-    File.open(@temp_diff_filename, 'w') { |f| f.write '' }
-
-    @filename_1 = File.join(@branch_1, 'some_test.txt')
-    @filename_2 = File.join(@branch_2, 'some_test.txt')
-    File.open(@filename_1, 'w') { |f| f.write '' }
-    File.open(@filename_2, 'w') { |f| f.write '' }
-  end
 end

--- a/test/unit/output_test.rb
+++ b/test/unit/output_test.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 class OutputTest < Ojo::OjoTestCase
 
   def test_not_too_long
-    s = ::Ojo::Output.new.send(:make_printable_name, 'Geordie', 10)
+    s = ::Ojo::Output.new(24).send(:make_printable_name, 'Geordie', 10)
     assert_equal 7, s.length
     assert_equal 'Geordie', s
   end
@@ -11,28 +11,28 @@ class OutputTest < Ojo::OjoTestCase
   def test_too_long_filename__even_max_odd_string
     max_length = 10
     starting_string = 'SomeOddNumberOfCharactersInThisString'
-    s = ::Ojo::Output.new.send(:make_printable_name, starting_string, max_length)
+    s = ::Ojo::Output.new(24).send(:make_printable_name, starting_string, max_length)
     assert_equal 'Som....ing', s
   end
 
   def test_too_long_filename__even_max_even_string
     max_length = 10
     starting_string = 'SomeEvenNumberOfCharactersInThisString'
-    s = ::Ojo::Output.new.send(:make_printable_name, starting_string, max_length)
+    s = ::Ojo::Output.new(24).send(:make_printable_name, starting_string, max_length)
     assert_equal 'Som....ng', s
   end
 
   def test_too_long_filename__odd_max_odd_string
     max_length = 11
     starting_string = 'SomeOddNumberOfCharactersInThisString'
-    s = ::Ojo::Output.new.send(:make_printable_name, starting_string, max_length)
+    s = ::Ojo::Output.new(24).send(:make_printable_name, starting_string, max_length)
     assert_equal 'Som....ing', s
   end
 
   def test_too_long_filename__odd_max_even_string
     max_length = 11
     starting_string = 'SomeEvenNumberOfCharactersInThisString'
-    s = ::Ojo::Output.new.send(:make_printable_name, starting_string, max_length)
+    s = ::Ojo::Output.new(24).send(:make_printable_name, starting_string, max_length)
     assert_equal 'Some....ing', s
   end
 end

--- a/test/unit/sorter_test.rb
+++ b/test/unit/sorter_test.rb
@@ -1,0 +1,30 @@
+require_relative '../test_helper'
+
+class SorterTest < Ojo::OjoTestCase
+
+  def test_sort_results
+    results = {:results => [
+        { :same => true,  :file_1 => 'full_1/file_1', :file_2 => 'full_1/file_2', :not_same_pixel_count => 0   },
+        { :same => false, :file_1 => 'full_2/file_1', :file_2 => 'full_2/file_2', :not_same_pixel_count => 31  },
+        { :same => false, :file_1 => 'full_3/file_1', :file_2 => 'full_3/file_2', :not_same_pixel_count => 12  },
+        { :same => false, :file_1 => 'full_4/file_1', :file_2 => 'full_4/file_2', :not_same_pixel_count => 55  },
+        { :same => true,  :file_1 => 'full_5/file_1', :file_2 => 'full_5/file_2', :not_same_pixel_count => 0   },
+        { :same => false, :file_1 => 'full_6/file_1', :file_2 => 'full_6/file_2', :not_same_pixel_count => 33  },
+        { :same => false, :file_1 => 'full_7/file_1', :file_2 => 'full_7/file_2', :not_same_pixel_count => 100 },
+        { :same => true,  :file_1 => 'full_8/file_1', :file_2 => 'full_8/file_2', :not_same_pixel_count => 0   },
+        { :same => false, :file_1 => 'full_9/file_1', :file_2 => 'full_9/file_2', :not_same_pixel_count => 63  }
+      ]
+    }
+
+    expected_sorted_order = %w(full_7 full_9 full_4 full_6 full_2 full_3)
+
+    sorter = ::Ojo::Sorter.new(results, 24)
+    sorted_results = sorter.sort
+
+    assert_equal results[:results].count, sorted_results.count
+
+    expected_sorted_order.each_with_index do |file, i|
+      assert_match file, sorted_results[i][:file_1]
+    end
+  end
+end


### PR DESCRIPTION
- add sorter to display by magnitude of failure
- add demo tests that are not really tests, but tasks that will display what things look like.
- us log scale for failure magnitude.
- update README with new output look.
